### PR TITLE
Improve type safety, error handling, and test coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,10 +20,10 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      statements: 18,
-      branches: 8,
-      functions: 16,
-      lines: 18
+      statements: 55,
+      branches: 45,
+      functions: 45,
+      lines: 55
     }
   }
 };

--- a/src/auth/providers/google-provider.ts
+++ b/src/auth/providers/google-provider.ts
@@ -4,6 +4,7 @@
 
 import { Request, Response } from 'express';
 import { OAuth2Client } from 'google-auth-library';
+import type { CodeChallengeMethod } from 'google-auth-library/build/src/auth/oauth2client.js';
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { BaseOAuthProvider } from './base-provider.js';
 import {
@@ -82,7 +83,7 @@ export class GoogleOAuthProvider extends BaseOAuthProvider {
         scope: session.scopes,
         state,
         code_challenge: codeChallenge,
-        code_challenge_method: 'S256' as any,
+        code_challenge_method: 'S256' as CodeChallengeMethod,
         prompt: 'consent',
       });
 

--- a/src/auth/providers/types.ts
+++ b/src/auth/providers/types.ts
@@ -99,6 +99,16 @@ export interface OAuthTokenResponse {
   user: OAuthUserInfo;
 }
 
+export interface ProviderTokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  id_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+  [key: string]: unknown;
+}
+
 /**
  * OAuth session data stored during the flow
  */
@@ -203,6 +213,11 @@ export interface OAuthProvider extends OAuthTokenVerifier {
    * Clean up expired sessions and tokens
    */
   cleanup(): void;
+
+  /**
+   * Release resources held by the provider (timers, open handles, etc.)
+   */
+  dispose(): void;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,23 +184,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // LLM-powered tools
       case "chat": {
-        const { handleChatTool } = await import('./tools/llm/chat.js');
-        return await handleChatTool(args as any, llmManager);
+        const { handleChatTool, parseChatToolInput } = await import('./tools/llm/chat.js');
+        const parsedArgs = parseChatToolInput(args);
+        return await handleChatTool(parsedArgs, llmManager);
       }
 
       case "analyze": {
-        const { handleAnalyzeTool } = await import('./tools/llm/analyze.js');
-        return await handleAnalyzeTool(args as any, llmManager);
+        const { handleAnalyzeTool, parseAnalyzeToolInput } = await import('./tools/llm/analyze.js');
+        const parsedArgs = parseAnalyzeToolInput(args);
+        return await handleAnalyzeTool(parsedArgs, llmManager);
       }
 
       case "summarize": {
-        const { handleSummarizeTool } = await import('./tools/llm/summarize.js');
-        return await handleSummarizeTool(args as any, llmManager);
+        const { handleSummarizeTool, parseSummarizeToolInput } = await import('./tools/llm/summarize.js');
+        const parsedArgs = parseSummarizeToolInput(args);
+        return await handleSummarizeTool(parsedArgs, llmManager);
       }
 
       case "explain": {
-        const { handleExplainTool } = await import('./tools/llm/explain.js');
-        return await handleExplainTool(args as any, llmManager);
+        const { handleExplainTool, parseExplainToolInput } = await import('./tools/llm/explain.js');
+        const parsedArgs = parseExplainToolInput(args);
+        return await handleExplainTool(parsedArgs, llmManager);
       }
 
       default:
@@ -216,12 +220,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
 
     // For other errors, return error content in response
+    const errorPayload = {
+      tool: name,
+      code: 'TOOL_EXECUTION_ERROR',
+      message: errorMessage
+    };
     return {
       content: [
         {
           type: "text",
           text: `Error executing tool '${name}': ${errorMessage}`,
         },
+        {
+          type: 'json',
+          json: { error: errorPayload }
+        }
       ],
     };
   }

--- a/src/secrets/managers/file.ts
+++ b/src/secrets/managers/file.ts
@@ -53,7 +53,8 @@ export class FileSecretManager implements SecretManager {
       }
       this.loaded = true;
     } catch (error) {
-      throw new Error(`Failed to load ${this.envPath}: ${error}`);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to load ${this.envPath}: ${message}`);
     }
   }
 }

--- a/test/unit/auth/providers/base-provider.test.ts
+++ b/test/unit/auth/providers/base-provider.test.ts
@@ -1,0 +1,281 @@
+import { jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+import {
+  BaseOAuthProvider
+} from '../../../../src/auth/providers/base-provider.js';
+import type {
+  OAuthConfig,
+  OAuthEndpoints,
+  OAuthProviderType,
+  OAuthSession,
+  OAuthUserInfo,
+  ProviderTokenResponse,
+  StoredTokenInfo
+} from '../../../../src/auth/providers/types.js';
+import { OAuthTokenError } from '../../../../src/auth/providers/types.js';
+
+type MockResponse = Response & {
+  statusCode?: number;
+  jsonPayload?: unknown;
+};
+
+const createResponse = (): MockResponse => {
+  const res: Partial<Response> & {
+    statusCode?: number;
+    jsonPayload?: unknown;
+  } = {};
+  res.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  });
+  res.json = jest.fn((payload: unknown) => {
+    res.jsonPayload = payload;
+    return res as Response;
+  });
+  res.redirect = jest.fn(() => res as Response);
+  return res as MockResponse;
+};
+
+type SessionAccess = {
+  storeSession(state: string, session: OAuthSession): void;
+  getSession(state: string): OAuthSession | undefined;
+  removeSession(state: string): void;
+  storeToken(token: string, info: StoredTokenInfo): void;
+  getToken(token: string): StoredTokenInfo | undefined;
+  removeToken(token: string): void;
+  cleanup(): void;
+};
+
+class TestOAuthProvider extends BaseOAuthProvider {
+  constructor(config: OAuthConfig) {
+    super(config);
+  }
+
+  getProviderType(): OAuthProviderType {
+    return 'google';
+  }
+
+  getProviderName(): string {
+    return 'Test';
+  }
+
+  getEndpoints(): OAuthEndpoints {
+    return {
+      authEndpoint: '/auth',
+      callbackEndpoint: '/callback',
+      refreshEndpoint: '/refresh',
+      logoutEndpoint: '/logout'
+    };
+  }
+
+  getDefaultScopes(): string[] {
+    return ['scope'];
+  }
+
+  async handleAuthorizationRequest(_req: Request, _res: Response): Promise<void> {}
+
+  async handleAuthorizationCallback(_req: Request, _res: Response): Promise<void> {}
+
+  async handleTokenRefresh(_req: Request, _res: Response): Promise<void> {}
+
+  async handleLogout(_req: Request, _res: Response): Promise<void> {}
+
+  async verifyAccessToken(token: string) {
+    return {
+      token,
+      clientId: this.config.clientId,
+      scopes: ['scope'],
+      expiresAt: Math.floor((Date.now() + 1000) / 1000),
+      extra: {
+        userInfo: await this.getUserInfo(token),
+        provider: 'google'
+      }
+    };
+  }
+
+  async getUserInfo(_accessToken: string): Promise<OAuthUserInfo> {
+    return {
+      sub: '123',
+      provider: 'google',
+      email: 'user@example.com',
+      name: 'User'
+    };
+  }
+}
+
+const baseConfig: OAuthConfig = {
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  redirectUri: 'https://example.com/callback',
+  scopes: ['scope'],
+  type: 'google'
+};
+
+describe('BaseOAuthProvider', () => {
+  let provider: TestOAuthProvider;
+  let sessionAccess: SessionAccess;
+  let originalFetch: typeof globalThis.fetch;
+  const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+  beforeAll(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    fetchMock.mockReset();
+    provider = new TestOAuthProvider(baseConfig);
+    sessionAccess = provider as unknown as SessionAccess;
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    jest.useRealTimers();
+  });
+
+  const jsonReply = <T>(body: T, init?: { status?: number; statusText?: string }) => {
+    const payload = typeof body === 'string' ? body : JSON.stringify(body);
+    return new Response(payload, {
+      status: init?.status ?? 200,
+      statusText: init?.statusText,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  };
+
+  it('cleans up expired sessions and tokens', () => {
+    const now = Date.now();
+    const expiredSession: OAuthSession = {
+      state: 'expired',
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+      redirectUri: baseConfig.redirectUri,
+      scopes: ['scope'],
+      provider: 'google',
+      expiresAt: now - 10
+    };
+
+    sessionAccess.storeSession('expired', expiredSession);
+    sessionAccess.storeSession('valid', { ...expiredSession, state: 'valid', expiresAt: now + 5000 });
+
+    sessionAccess.storeToken('expired-token', {
+      accessToken: 'expired-token',
+      expiresAt: now - 10,
+      provider: 'google',
+      scopes: ['scope'],
+      userInfo: {
+        sub: '123',
+        provider: 'google',
+        email: 'user@example.com',
+        name: 'User'
+      }
+    });
+
+    sessionAccess.storeToken('valid-token', {
+      accessToken: 'valid-token',
+      expiresAt: now + 60_000,
+      provider: 'google',
+      scopes: ['scope'],
+      userInfo: {
+        sub: '123',
+        provider: 'google',
+        email: 'user@example.com',
+        name: 'User'
+      }
+    });
+
+    sessionAccess.cleanup();
+
+    const tokenStore = provider as unknown as { tokens: Map<string, StoredTokenInfo> };
+
+    expect(sessionAccess.getSession('expired')).toBeUndefined();
+    expect(sessionAccess.getSession('valid')).toBeDefined();
+    expect(sessionAccess.getToken('expired-token')).toBeUndefined();
+    expect(tokenStore.tokens.has('valid-token')).toBe(true);
+  });
+
+  it('removes tokens that are expiring within buffer during validation', async () => {
+    const now = Date.now();
+    sessionAccess.storeToken('token', {
+      accessToken: 'token',
+      expiresAt: now + 500,
+      provider: 'google',
+      scopes: ['scope'],
+      userInfo: {
+        sub: '123',
+        provider: 'google',
+        email: 'user@example.com',
+        name: 'User'
+      }
+    });
+
+    const result = await provider.isTokenValid('token');
+    expect(result).toBe(false);
+    expect(sessionAccess.getToken('token')).toBeUndefined();
+  });
+
+  it('exchanges authorization code for tokens and returns JSON response', async () => {
+    fetchMock.mockResolvedValueOnce(jsonReply<ProviderTokenResponse>({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      token_type: 'Bearer',
+      scope: 'scope'
+    }));
+
+    const response = await provider['exchangeCodeForTokens']('https://token.url', 'code', 'verifier', { audience: 'value' });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://token.url', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ 'Content-Type': 'application/x-www-form-urlencoded' }),
+    }));
+    expect(response).toEqual(expect.objectContaining({ access_token: 'access-token' }));
+  });
+
+  it('throws OAuthTokenError when token exchange fails', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('bad request', {
+      status: 400,
+      statusText: 'Bad Request'
+    }));
+
+    await expect(
+      provider['exchangeCodeForTokens']('https://token.url', 'code', 'verifier')
+    ).rejects.toThrow(OAuthTokenError);
+  });
+
+  it('refreshes tokens via refreshAccessToken helper', async () => {
+    fetchMock.mockResolvedValueOnce(jsonReply<ProviderTokenResponse>({
+      access_token: 'new-access',
+      token_type: 'Bearer'
+    }));
+
+    const response = await provider['refreshAccessToken']('https://token.url', 'refresh-token');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://token.url', expect.objectContaining({
+      method: 'POST'
+    }));
+    expect(response.access_token).toBe('new-access');
+  });
+
+  it('throws when refreshAccessToken receives an error response', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('bad refresh', {
+      status: 500,
+      statusText: 'Server Error'
+    }));
+
+    await expect(
+      provider['refreshAccessToken']('https://token.url', 'refresh-token')
+    ).rejects.toThrow(OAuthTokenError);
+  });
+
+  it('clears cleanup timers on dispose', () => {
+    const clearSpy = jest.spyOn(global, 'clearInterval');
+    provider.dispose();
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});

--- a/test/unit/auth/providers/github-provider.test.ts
+++ b/test/unit/auth/providers/github-provider.test.ts
@@ -1,0 +1,288 @@
+import { jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+import type {
+  GitHubOAuthConfig,
+  OAuthSession,
+  StoredTokenInfo,
+  OAuthUserInfo
+} from '../../../../src/auth/providers/types.js';
+
+let originalFetch: typeof globalThis.fetch;
+const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+const baseConfig: GitHubOAuthConfig = {
+  type: 'github',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  redirectUri: 'https://example.com/callback',
+  scopes: ['user:email']
+};
+
+type MockResponse = Response & {
+  statusCode?: number;
+  jsonPayload?: unknown;
+  redirectUrl?: string;
+};
+
+const createMockResponse = (): MockResponse => {
+  const data: Partial<Response> & {
+    statusCode?: number;
+    jsonPayload?: unknown;
+    redirectUrl?: string;
+  } = {};
+
+  data.status = jest.fn((code: number) => {
+    data.statusCode = code;
+    return data as Response;
+  });
+  data.json = jest.fn((payload: unknown) => {
+    data.jsonPayload = payload;
+    return data as Response;
+  });
+  data.redirect = jest.fn((statusOrUrl: number | string, maybeUrl?: string) => {
+    if (typeof statusOrUrl === 'number') {
+      data.statusCode = statusOrUrl;
+      data.redirectUrl = maybeUrl ?? '';
+    } else {
+      data.redirectUrl = statusOrUrl;
+    }
+    return data as Response;
+  });
+
+  return data as MockResponse;
+};
+
+const jsonReply = <T>(body: T, init?: { status?: number; statusText?: string }) => {
+  const payload = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(payload, {
+    status: init?.status ?? 200,
+    statusText: init?.statusText,
+    headers: { 'Content-Type': 'application/json' }
+  });
+};
+
+let GitHubOAuthProvider: typeof import('../../../../src/auth/providers/github-provider.js').GitHubOAuthProvider;
+
+beforeAll(async () => {
+  ({ GitHubOAuthProvider } = await import('../../../../src/auth/providers/github-provider.js'));
+});
+
+describe('GitHubOAuthProvider', () => {
+  beforeAll(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    jest.clearAllMocks();
+  });
+
+  const createProvider = () => new GitHubOAuthProvider(baseConfig);
+
+  it('redirects to GitHub authorization URL and stores session data', async () => {
+    const provider = createProvider();
+
+    const pkceSpy = jest.spyOn(provider as unknown as { generatePKCE: () => { codeVerifier: string; codeChallenge: string } }, 'generatePKCE')
+      .mockReturnValue({ codeVerifier: 'verifier', codeChallenge: 'challenge' });
+    const stateSpy = jest.spyOn(provider as unknown as { generateState: () => string }, 'generateState')
+      .mockReturnValue('state123');
+
+    const res = createMockResponse();
+    await provider.handleAuthorizationRequest({} as Request, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    const redirectUrl = res.redirectUrl ?? '';
+    expect(redirectUrl).toContain('https://github.com/login/oauth/authorize');
+    expect(redirectUrl).toContain('client_id=client-id');
+    expect(redirectUrl).toContain('code_challenge=challenge');
+    expect(redirectUrl).toContain('state=state123');
+
+    const session = (provider as unknown as { getSession: (state: string) => OAuthSession | undefined }).getSession('state123');
+    expect(session).toBeDefined();
+    expect(session?.provider).toBe('github');
+
+    pkceSpy.mockRestore();
+    stateSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('exchanges code for tokens and fetches user info during callback', async () => {
+    const provider = createProvider();
+    const now = Date.now();
+    (provider as unknown as { storeSession: (state: string, session: OAuthSession) => void }).storeSession('state123', {
+      state: 'state123',
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+      redirectUri: baseConfig.redirectUri,
+      scopes: baseConfig.scopes,
+      provider: 'github',
+      expiresAt: now + 5_000
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(jsonReply({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        scope: 'user:email',
+        expires_in: 3600
+      }))
+      .mockResolvedValueOnce(jsonReply({
+        id: 42,
+        email: null,
+        login: 'octocat',
+        name: 'The Octocat',
+        avatar_url: 'avatar.png'
+      }))
+      .mockResolvedValueOnce(jsonReply([
+        { email: 'octo@example.com', primary: true }
+      ]));
+
+    const res = createMockResponse();
+
+    await provider.handleAuthorizationCallback({
+      query: { code: 'code123', state: 'state123' }
+    } as unknown as Request, res);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1,
+      'https://github.com/login/oauth/access_token',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(2,
+      'https://api.github.com/user',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer access-token' }) })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(3,
+      'https://api.github.com/user/emails',
+      expect.any(Object)
+    );
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      access_token: 'access-token',
+      user: expect.objectContaining({ email: 'octo@example.com', provider: 'github' })
+    }));
+
+    const sessionAfter = (provider as unknown as { getSession: (state: string) => OAuthSession | undefined }).getSession('state123');
+    expect(sessionAfter).toBeUndefined();
+
+    const storedToken = (provider as unknown as { getToken: (token: string) => StoredTokenInfo | undefined }).getToken('access-token');
+    expect(storedToken?.userInfo.email).toBe('octo@example.com');
+
+    provider.dispose();
+  });
+
+  it('returns 500 when token exchange does not provide access token', async () => {
+    const provider = createProvider();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (provider as unknown as { storeSession: (state: string, session: OAuthSession) => void }).storeSession('state123', {
+      state: 'state123',
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+      redirectUri: baseConfig.redirectUri,
+      scopes: baseConfig.scopes,
+      provider: 'github',
+      expiresAt: Date.now() + 5_000
+    });
+
+    fetchMock.mockResolvedValueOnce(jsonReply({}));
+
+    const res = createMockResponse();
+
+    await provider.handleAuthorizationCallback({
+      query: { code: 'code123', state: 'state123' }
+    } as unknown as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Authorization failed' }));
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('returns cached token information when refreshing an existing token', async () => {
+    const provider = createProvider();
+    const future = Date.now() + 3_600_000;
+    const stored: StoredTokenInfo = {
+      accessToken: 'access-token',
+      refreshToken: undefined,
+      expiresAt: future,
+      userInfo: {
+        sub: '42',
+        email: 'octo@example.com',
+        name: 'The Octocat',
+        provider: 'github',
+        providerData: {}
+      },
+      provider: 'github',
+      scopes: baseConfig.scopes
+    };
+
+    (provider as unknown as { storeToken: (token: string, info: StoredTokenInfo) => void }).storeToken('access-token', stored);
+
+    const res = createMockResponse();
+    await provider.handleTokenRefresh({
+      body: { access_token: 'access-token' }
+    } as unknown as Request, res);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      access_token: 'access-token',
+      token_type: 'Bearer'
+    }));
+
+    provider.dispose();
+  });
+
+  it('rejects refresh requests for unknown tokens', async () => {
+    const provider = createProvider();
+    const res = createMockResponse();
+
+    await provider.handleTokenRefresh({
+      body: { access_token: 'missing-token' }
+    } as unknown as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Token is no longer valid' });
+
+    provider.dispose();
+  });
+
+  it('verifies access tokens via GitHub API when not cached', async () => {
+    const provider = createProvider();
+
+    fetchMock.mockResolvedValueOnce(jsonReply({
+      id: 7,
+      email: 'code@example.com',
+      login: 'coder',
+      name: 'Code Master',
+      avatar_url: 'avatar.png'
+    }));
+
+    const authInfo = await provider.verifyAccessToken('remote-token');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.github.com/user', expect.any(Object));
+    expect(authInfo.extra?.userInfo).toMatchObject({ email: 'code@example.com' });
+
+    provider.dispose();
+  });
+
+  it('throws when GitHub user info cannot be retrieved', async () => {
+    const provider = createProvider();
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    fetchMock.mockResolvedValueOnce(new Response('error', {
+      status: 500,
+      statusText: 'Internal Server Error'
+    }));
+
+    await expect(provider.getUserInfo('missing-token')).rejects.toThrow('Failed to get user information');
+
+    consoleSpy.mockRestore();
+    provider.dispose();
+  });
+});

--- a/test/unit/auth/providers/google-provider.test.ts
+++ b/test/unit/auth/providers/google-provider.test.ts
@@ -1,0 +1,271 @@
+import { jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+import type { GoogleOAuthConfig, OAuthSession, StoredTokenInfo } from '../../../../src/auth/providers/types.js';
+
+const mockGenerateAuthUrl = jest.fn<(options: Record<string, unknown>) => string>();
+const mockGetToken = jest.fn<(options: Record<string, unknown>) => Promise<{ tokens: Record<string, unknown> }>>();
+const mockVerifyIdToken = jest.fn<(options: Record<string, unknown>) => Promise<{ getPayload: () => Record<string, unknown> }>>();
+const mockRefreshAccessToken = jest.fn<() => Promise<{ credentials: Record<string, unknown> }>>();
+const mockSetCredentials = jest.fn<(options: Record<string, unknown>) => void>();
+
+jest.mock('google-auth-library', () => ({
+  OAuth2Client: jest.fn(() => ({
+    generateAuthUrl: mockGenerateAuthUrl,
+    getToken: mockGetToken,
+    verifyIdToken: mockVerifyIdToken,
+    refreshAccessToken: mockRefreshAccessToken,
+    setCredentials: mockSetCredentials
+  }))
+}));
+
+let GoogleOAuthProvider: typeof import('../../../../src/auth/providers/google-provider.js').GoogleOAuthProvider;
+
+beforeAll(async () => {
+  ({ GoogleOAuthProvider } = await import('../../../../src/auth/providers/google-provider.js'));
+});
+
+const baseConfig: GoogleOAuthConfig = {
+  type: 'google',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  redirectUri: 'https://example.com/callback',
+  scopes: ['openid', 'email']
+};
+
+type MockResponse = Response & {
+  statusCode?: number;
+  jsonPayload?: unknown;
+  redirectUrl?: string;
+};
+
+const createMockResponse = (): MockResponse => {
+  const data: Partial<Response> & {
+    statusCode?: number;
+    jsonPayload?: unknown;
+    redirectUrl?: string;
+  } = {};
+
+  data.status = jest.fn((code: number) => {
+    data.statusCode = code;
+    return data as Response;
+  });
+  data.json = jest.fn((payload: unknown) => {
+    data.jsonPayload = payload;
+    return data as Response;
+  });
+  data.redirect = jest.fn((statusOrUrl: number | string, maybeUrl?: string) => {
+    if (typeof statusOrUrl === 'number') {
+      data.statusCode = statusOrUrl;
+      data.redirectUrl = maybeUrl ?? '';
+    } else {
+      data.redirectUrl = statusOrUrl;
+    }
+    return data as Response;
+  });
+
+  return data as MockResponse;
+};
+
+describe('GoogleOAuthProvider', () => {
+  const createProvider = () => new GoogleOAuthProvider(baseConfig);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateAuthUrl.mockReturnValue('https://accounts.google.com/o/oauth2/auth?state=state123');
+  });
+
+  it('redirects to Google authorization URL and stores session data', async () => {
+    const provider = createProvider();
+
+    const pkceSpy = jest.spyOn(provider as unknown as { generatePKCE: () => { codeVerifier: string; codeChallenge: string } }, 'generatePKCE')
+      .mockReturnValue({ codeVerifier: 'verifier', codeChallenge: 'challenge' });
+    const stateSpy = jest.spyOn(provider as unknown as { generateState: () => string }, 'generateState')
+      .mockReturnValue('state123');
+
+    const res = createMockResponse();
+    await provider.handleAuthorizationRequest({} as Request, res);
+
+    expect(mockGenerateAuthUrl).toHaveBeenCalledWith({
+      access_type: 'offline',
+      scope: ['openid', 'email'],
+      state: 'state123',
+      code_challenge: 'challenge',
+      code_challenge_method: 'S256',
+      prompt: 'consent'
+    });
+    expect(res.redirect).toHaveBeenCalledWith('https://accounts.google.com/o/oauth2/auth?state=state123');
+
+    const session = (provider as unknown as { getSession: (state: string) => OAuthSession | undefined }).getSession('state123');
+    expect(session).toMatchObject({
+      state: 'state123',
+      codeVerifier: 'verifier',
+      provider: 'google'
+    });
+
+    pkceSpy.mockRestore();
+    stateSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('exchanges code for tokens and returns user info during callback', async () => {
+    const provider = createProvider();
+    const now = 1_000_000;
+    const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    (provider as unknown as { storeSession: (state: string, session: OAuthSession) => void }).storeSession('state123', {
+      state: 'state123',
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+      redirectUri: baseConfig.redirectUri,
+      scopes: ['openid', 'email'],
+      provider: 'google',
+      expiresAt: now + 5_000
+    });
+
+    mockGetToken.mockResolvedValueOnce({
+      tokens: {
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        id_token: 'id-token',
+        expiry_date: now + 3_600_000
+      }
+    });
+    mockVerifyIdToken.mockResolvedValueOnce({
+      getPayload: () => ({
+        sub: '123',
+        email: 'user@example.com',
+        name: 'Test User',
+        picture: 'avatar.png'
+      })
+    });
+
+    const res = createMockResponse();
+
+    await provider.handleAuthorizationCallback({
+      query: { code: 'code123', state: 'state123' }
+    } as unknown as Request, res);
+
+    expect(mockGetToken).toHaveBeenCalledWith({
+      code: 'code123',
+      codeVerifier: 'verifier'
+    });
+    expect(mockVerifyIdToken).toHaveBeenCalledWith({
+      idToken: 'id-token',
+      audience: 'client-id'
+    });
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      token_type: 'Bearer',
+      user: expect.objectContaining({ email: 'user@example.com', provider: 'google' })
+    }));
+
+    const sessionAfter = (provider as unknown as { getSession: (state: string) => OAuthSession | undefined }).getSession('state123');
+    expect(sessionAfter).toBeUndefined();
+
+    const storedToken = (provider as unknown as { getToken: (token: string) => StoredTokenInfo | undefined }).getToken('access-token');
+    expect(storedToken).toBeDefined();
+    expect(storedToken?.userInfo.email).toBe('user@example.com');
+
+    dateSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('returns 500 when Google does not supply an access token', async () => {
+    const provider = createProvider();
+    const now = 2_000_000;
+    const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+    (provider as unknown as { storeSession: (state: string, session: OAuthSession) => void }).storeSession('state123', {
+      state: 'state123',
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+      redirectUri: baseConfig.redirectUri,
+      scopes: baseConfig.scopes,
+      provider: 'google',
+      expiresAt: now + 5_000
+    });
+
+    mockGetToken.mockResolvedValueOnce({ tokens: {} });
+
+    const res = createMockResponse();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await provider.handleAuthorizationCallback({
+      query: { code: 'code123', state: 'state123' }
+    } as unknown as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Authorization failed' }));
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    dateSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('refreshes tokens when provided a valid refresh token', async () => {
+    const provider = createProvider();
+    const now = 3_000_000;
+    const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    const existingToken: StoredTokenInfo = {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      idToken: 'id-token',
+      expiresAt: now + 1_000,
+      userInfo: {
+        sub: '123',
+        email: 'user@example.com',
+        name: 'Test User',
+        provider: 'google'
+      },
+      provider: 'google',
+      scopes: baseConfig.scopes
+    };
+
+    (provider as unknown as { storeToken: (accessToken: string, info: StoredTokenInfo) => void }).storeToken('access-token', existingToken);
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      credentials: {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expiry_date: now + 7_200_000
+      }
+    });
+
+    const res = createMockResponse();
+
+    await provider.handleTokenRefresh({
+      body: { refresh_token: 'refresh-token' }
+    } as unknown as Request, res);
+
+    expect(mockSetCredentials).toHaveBeenCalledWith({ refresh_token: 'refresh-token' });
+    expect(mockRefreshAccessToken).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token'
+    }));
+
+    const updatedToken = (provider as unknown as { getToken: (token: string) => StoredTokenInfo | undefined }).getToken('new-access-token');
+    expect(updatedToken).toBeDefined();
+    expect(updatedToken?.refreshToken).toBe('new-refresh-token');
+
+    dateSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('returns 401 when refresh token is unknown', async () => {
+    const provider = createProvider();
+    const res = createMockResponse();
+
+    await provider.handleTokenRefresh({
+      body: { refresh_token: 'missing-token' }
+    } as unknown as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid refresh token' });
+
+    provider.dispose();
+  });
+});

--- a/test/unit/auth/providers/microsoft-provider.test.ts
+++ b/test/unit/auth/providers/microsoft-provider.test.ts
@@ -1,0 +1,313 @@
+import { jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+import type {
+  MicrosoftOAuthConfig,
+  OAuthSession,
+  StoredTokenInfo
+} from '../../../../src/auth/providers/types.js';
+
+let originalFetch: typeof globalThis.fetch;
+const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+const baseConfig: MicrosoftOAuthConfig = {
+  type: 'microsoft',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  redirectUri: 'https://example.com/callback',
+  scopes: ['openid', 'profile'],
+  tenantId: 'common'
+};
+
+type MockResponse = Response & {
+  statusCode?: number;
+  jsonPayload?: unknown;
+  redirectUrl?: string;
+};
+
+const createMockResponse = (): MockResponse => {
+  const data: Partial<Response> & {
+    statusCode?: number;
+    jsonPayload?: unknown;
+    redirectUrl?: string;
+  } = {};
+
+  data.status = jest.fn((code: number) => {
+    data.statusCode = code;
+    return data as Response;
+  });
+  data.json = jest.fn((payload: unknown) => {
+    data.jsonPayload = payload;
+    return data as Response;
+  });
+  data.redirect = jest.fn((statusOrUrl: number | string, maybeUrl?: string) => {
+    if (typeof statusOrUrl === 'number') {
+      data.statusCode = statusOrUrl;
+      data.redirectUrl = maybeUrl ?? '';
+    } else {
+      data.redirectUrl = statusOrUrl;
+    }
+    return data as Response;
+  });
+
+  return data as MockResponse;
+};
+
+const jsonReply = <T>(body: T, init?: { status?: number; statusText?: string }) => {
+  const payload = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(payload, {
+    status: init?.status ?? 200,
+    statusText: init?.statusText,
+    headers: { 'Content-Type': 'application/json' }
+  });
+};
+
+let MicrosoftOAuthProvider: typeof import('../../../../src/auth/providers/microsoft-provider.js').MicrosoftOAuthProvider;
+
+beforeAll(async () => {
+  ({ MicrosoftOAuthProvider } = await import('../../../../src/auth/providers/microsoft-provider.js'));
+});
+
+describe('MicrosoftOAuthProvider', () => {
+  beforeAll(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    jest.clearAllMocks();
+  });
+
+  const createProvider = () => new MicrosoftOAuthProvider(baseConfig);
+
+  it('redirects to Microsoft authorization URL and stores session data', async () => {
+    const provider = createProvider();
+
+    const pkceSpy = jest.spyOn(provider as unknown as { generatePKCE: () => { codeVerifier: string; codeChallenge: string } }, 'generatePKCE')
+      .mockReturnValue({ codeVerifier: 'verifier', codeChallenge: 'challenge' });
+    const stateSpy = jest.spyOn(provider as unknown as { generateState: () => string }, 'generateState')
+      .mockReturnValue('state123');
+
+    const res = createMockResponse();
+    await provider.handleAuthorizationRequest({} as Request, res);
+
+    const redirectUrl = res.redirectUrl ?? '';
+    expect(redirectUrl).toContain('https://login.microsoftonline.com/common/oauth2/v2.0/authorize');
+    expect(redirectUrl).toContain('client_id=client-id');
+    expect(redirectUrl).toContain('code_challenge=challenge');
+
+    const session = (provider as unknown as { getSession: (state: string) => OAuthSession | undefined }).getSession('state123');
+    expect(session).toBeDefined();
+    expect(session?.provider).toBe('microsoft');
+
+    pkceSpy.mockRestore();
+    stateSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('handles authorization callback, exchanging code and fetching user info', async () => {
+    const provider = createProvider();
+    (provider as unknown as { storeSession: (state: string, session: OAuthSession) => void }).storeSession('state123', {
+      state: 'state123',
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+      redirectUri: baseConfig.redirectUri,
+      scopes: baseConfig.scopes,
+      provider: 'microsoft',
+      expiresAt: Date.now() + 5_000
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(jsonReply({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        id_token: 'id-token',
+        scope: 'openid profile',
+        expires_in: 3600
+      }))
+      .mockResolvedValueOnce(jsonReply({
+        id: 'user-id',
+        mail: 'user@example.com',
+        displayName: 'User Example'
+      }));
+
+    const res = createMockResponse();
+
+    await provider.handleAuthorizationCallback({
+      query: { code: 'code123', state: 'state123' }
+    } as unknown as Request, res);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1,
+      'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(2,
+      'https://graph.microsoft.com/v1.0/me',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer access-token' }) })
+    );
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      access_token: 'access-token',
+      user: expect.objectContaining({ email: 'user@example.com', provider: 'microsoft' })
+    }));
+
+    const storedToken = (provider as unknown as { getToken: (token: string) => StoredTokenInfo | undefined }).getToken('access-token');
+    expect(storedToken?.userInfo.email).toBe('user@example.com');
+
+    provider.dispose();
+  });
+
+  it('returns 500 when authorization callback lacks access token', async () => {
+    const provider = createProvider();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    (provider as unknown as { storeSession: (state: string, session: OAuthSession) => void }).storeSession('state123', {
+      state: 'state123',
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+      redirectUri: baseConfig.redirectUri,
+      scopes: baseConfig.scopes,
+      provider: 'microsoft',
+      expiresAt: Date.now() + 5_000
+    });
+
+    fetchMock.mockResolvedValueOnce(jsonReply({}));
+
+    const res = createMockResponse();
+
+    await provider.handleAuthorizationCallback({
+      query: { code: 'code123', state: 'state123' }
+    } as unknown as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Authorization failed' }));
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('refreshes tokens using the Microsoft token endpoint', async () => {
+    const provider = createProvider();
+    const now = Date.now();
+    const stored: StoredTokenInfo = {
+      accessToken: 'old-access',
+      refreshToken: 'refresh-token',
+      idToken: 'id-token',
+      expiresAt: now + 1_000,
+      userInfo: {
+        sub: 'user-id',
+        email: 'user@example.com',
+        name: 'User Example',
+        provider: 'microsoft'
+      },
+      provider: 'microsoft',
+      scopes: baseConfig.scopes
+    };
+
+    (provider as unknown as { storeToken: (token: string, info: StoredTokenInfo) => void }).storeToken('old-access', stored);
+
+    fetchMock.mockResolvedValueOnce(jsonReply({
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      expires_in: 7200
+    }));
+
+    const res = createMockResponse();
+
+    await provider.handleTokenRefresh({
+      body: { refresh_token: 'refresh-token' }
+    } as unknown as Request, res);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      access_token: 'new-access',
+      refresh_token: 'new-refresh'
+    }));
+
+    const newToken = (provider as unknown as { getToken: (token: string) => StoredTokenInfo | undefined }).getToken('new-access');
+    expect(newToken?.refreshToken).toBe('new-refresh');
+    expect((provider as unknown as { getToken: (token: string) => StoredTokenInfo | undefined }).getToken('old-access')).toBeUndefined();
+
+    provider.dispose();
+  });
+
+  it('rejects refresh requests with unknown refresh tokens', async () => {
+    const provider = createProvider();
+    const res = createMockResponse();
+
+    await provider.handleTokenRefresh({
+      body: { refresh_token: 'unknown' }
+    } as unknown as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid refresh token' });
+
+    provider.dispose();
+  });
+
+  it('revokes tokens on logout and remains successful even if revocation fails', async () => {
+    const provider = createProvider();
+
+    const stored: StoredTokenInfo = {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      idToken: 'id-token',
+      expiresAt: Date.now() + 3_600_000,
+      userInfo: {
+        sub: 'user-id',
+        email: 'user@example.com',
+        name: 'User Example',
+        provider: 'microsoft'
+      },
+      provider: 'microsoft',
+      scopes: baseConfig.scopes
+    };
+    (provider as unknown as { storeToken: (token: string, info: StoredTokenInfo) => void }).storeToken('access-token', stored);
+
+    fetchMock
+      .mockResolvedValueOnce(new Response('error', {
+        status: 500,
+        statusText: 'Error'
+      }));
+
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = createMockResponse();
+    await provider.handleLogout({
+      headers: { authorization: 'Bearer access-token' }
+    } as Request, res);
+
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+    expect((provider as unknown as { getToken: (token: string) => StoredTokenInfo | undefined }).getToken('access-token')).toBeUndefined();
+
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    provider.dispose();
+  });
+
+  it('throws when Microsoft user profile cannot be retrieved', async () => {
+    const provider = createProvider();
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    fetchMock.mockResolvedValueOnce(new Response('forbidden', {
+      status: 403,
+      statusText: 'Forbidden'
+    }));
+
+    await expect(provider.getUserInfo('token')).rejects.toThrow('Failed to get user information');
+
+    consoleSpy.mockRestore();
+    provider.dispose();
+  });
+});

--- a/test/unit/llm/config.test.ts
+++ b/test/unit/llm/config.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { LLMConfigManager } from '../../../src/llm/config.js';
+import type { LLMConfig } from '../../../src/llm/types.js';
 import type { SecretManager } from '../../../src/secrets/types.js';
 
 const createSecretManager = (overrides: Partial<SecretManager> = {}): SecretManager => ({
@@ -40,9 +41,92 @@ describe('LLMConfigManager', () => {
     });
 
     const manager = new LLMConfigManager(secretManager);
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     await expect(manager.validateConfig()).resolves.toBe(false);
-    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalled();
+  });
+
+  it('logs warnings and continues when some secrets fail to load', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const secretManager = createSecretManager({
+      getSecret: jest.fn<SecretManager['getSecret']>()
+        .mockRejectedValueOnce(new Error('anthropic missing'))
+        .mockResolvedValueOnce('openai-key')
+        .mockRejectedValueOnce(new Error('gemini missing'))
+        .mockRejectedValueOnce(new Error('default missing'))
+    });
+
+    const manager = new LLMConfigManager(secretManager);
+    const config = await manager.loadConfig();
+
+    expect(config.providers.claude.apiKey).toBe('');
+    expect(config.providers.openai.apiKey).toBe('openai-key');
+    expect(config.providers.gemini.apiKey).toBe('');
+    const warnMessages = warnSpy.mock.calls.reduce<string[]>((acc, call) => {
+      call.forEach(arg => acc.push(String(arg)));
+      return acc;
+    }, []);
+    expect(warnMessages.some(msg => msg.includes('Missing or invalid LLM API keys:'))).toBe(true);
+    expect(warnMessages.some(msg => msg.includes('Missing LLM API key values:'))).toBe(true);
+  });
+
+  it('validates config and warns when some providers lack keys', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const config: LLMConfig = {
+      defaultProvider: 'claude',
+      providers: {
+        claude: {
+          apiKey: 'anthropic-key',
+          defaultModel: 'claude-3-haiku-20240307',
+          models: {
+            'claude-3-haiku-20240307': { maxTokens: 4096, available: true },
+            'claude-3-sonnet-20240229': { maxTokens: 4096, available: true },
+            'claude-3-opus-20240229': { maxTokens: 4096, available: true }
+          }
+        },
+        openai: {
+          apiKey: '',
+          defaultModel: 'gpt-4',
+          models: {
+            'gpt-3.5-turbo': { maxTokens: 4096, available: true },
+            'gpt-4': { maxTokens: 4096, available: true },
+            'gpt-4-turbo': { maxTokens: 4096, available: true },
+            'gpt-4o': { maxTokens: 4096, available: true },
+            'gpt-4o-mini': { maxTokens: 4096, available: true }
+          }
+        },
+        gemini: {
+          apiKey: '',
+          defaultModel: 'gemini-1.5-flash',
+          models: {
+            'gemini-1.5-flash': { maxTokens: 4096, available: true },
+            'gemini-1.5-pro': { maxTokens: 4096, available: true },
+            'gemini-1.0-pro': { maxTokens: 4096, available: true }
+          }
+        }
+      },
+      timeout: 30_000,
+      defaultTemperature: 0.7,
+      cacheEnabled: true,
+      cacheTtl: 5 * 60 * 1000,
+      maxRetries: 2
+    };
+
+    const loadConfigSpy = jest.spyOn(LLMConfigManager.prototype, 'loadConfig').mockResolvedValue(config);
+    const manager = new LLMConfigManager(createSecretManager());
+
+    await expect(manager.validateConfig()).resolves.toBe(true);
+    expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+
+    const warnMessages = warnSpy.mock.calls.flatMap((call) => call.map((arg) => String(arg)));
+    expect(warnSpy).toHaveBeenCalled();
+    expect(
+      warnMessages.some((message) => message.includes('Missing API keys for provider(s):'))
+    ).toBe(true);
+    expect(warnMessages.join(' ')).toContain('openai');
+    expect(warnMessages.join(' ')).toContain('gemini');
   });
 
   it('throws when requesting a model that does not exist for the provider', async () => {
@@ -52,7 +136,7 @@ describe('LLMConfigManager', () => {
 
     const manager = new LLMConfigManager(secretManager);
 
-    await expect(manager.getModelConfig('openai', 'nonexistent'))
+    await expect(manager.getModelConfig('openai', 'nonexistent' as never))
       .rejects.toThrow("Model 'nonexistent' is not available for provider 'openai'");
   });
 

--- a/test/unit/llm/manager.test.ts
+++ b/test/unit/llm/manager.test.ts
@@ -1,82 +1,102 @@
 import { jest } from '@jest/globals';
 import { LLMManager } from '../../../src/llm/manager.js';
-import type { LLMConfig } from '../../../src/llm/types.js';
+import { LLMConfigManager } from '../../../src/llm/config.js';
+import type { LLMConfig, LLMProvider } from '../../../src/llm/types.js';
 import type { SecretManager } from '../../../src/secrets/types.js';
 
-describe('LLMManager', () => {
-  const baseConfig: LLMConfig = {
-    defaultProvider: 'claude',
-    providers: {
-      claude: {
-        apiKey: 'claude-key',
-        defaultModel: 'claude-3-haiku-20240307',
-        models: {
-          'claude-3-haiku-20240307': { maxTokens: 4096, available: true },
-          'claude-3-sonnet-20240229': { maxTokens: 4096, available: true },
-          'claude-3-opus-20240229': { maxTokens: 4096, available: true }
-        }
-      },
-      openai: {
-        apiKey: 'openai-key',
-        defaultModel: 'gpt-4',
-        models: {
-          'gpt-3.5-turbo': { maxTokens: 4096, available: true },
-          'gpt-4': { maxTokens: 4096, available: true },
-          'gpt-4-turbo': { maxTokens: 4096, available: true },
-          'gpt-4o': { maxTokens: 4096, available: true },
-          'gpt-4o-mini': { maxTokens: 4096, available: true }
-        }
-      },
-      gemini: {
-        apiKey: 'gemini-key',
-        defaultModel: 'gemini-1.5-flash',
-        models: {
-          'gemini-1.5-flash': { maxTokens: 4096, available: true },
-          'gemini-1.5-pro': { maxTokens: 4096, available: true },
-          'gemini-1.0-pro': { maxTokens: 4096, available: true }
-        }
+const baseConfig: LLMConfig = {
+  defaultProvider: 'claude',
+  providers: {
+    claude: {
+      apiKey: 'claude-key',
+      defaultModel: 'claude-3-haiku-20240307',
+      models: {
+        'claude-3-haiku-20240307': { maxTokens: 4096, available: true },
+        'claude-3-sonnet-20240229': { maxTokens: 4096, available: true },
+        'claude-3-opus-20240229': { maxTokens: 4096, available: true }
       }
     },
-    timeout: 30000,
-    defaultTemperature: 0.7,
-    cacheEnabled: true,
-    cacheTtl: 300000,
-    maxRetries: 2
-  };
+    openai: {
+      apiKey: 'openai-key',
+      defaultModel: 'gpt-4',
+      models: {
+        'gpt-3.5-turbo': { maxTokens: 4096, available: true },
+        'gpt-4': { maxTokens: 4096, available: true },
+        'gpt-4-turbo': { maxTokens: 4096, available: true },
+        'gpt-4o': { maxTokens: 4096, available: true },
+        'gpt-4o-mini': { maxTokens: 4096, available: true }
+      }
+    },
+    gemini: {
+      apiKey: 'gemini-key',
+      defaultModel: 'gemini-1.5-flash',
+      models: {
+        'gemini-1.5-flash': { maxTokens: 4096, available: true },
+        'gemini-1.5-pro': { maxTokens: 4096, available: true },
+        'gemini-1.0-pro': { maxTokens: 4096, available: true }
+      }
+    }
+  },
+  timeout: 30_000,
+  defaultTemperature: 0.7,
+  cacheEnabled: true,
+  cacheTtl: 300_000,
+  maxRetries: 2
+};
 
+const createSecretManager = (): SecretManager => ({
+  async getSecret() {
+    return '';
+  },
+  async isAvailable() {
+    return true;
+  },
+  getName() {
+    return 'test-secret-manager';
+  }
+});
+
+const setupConfigSpies = (config: LLMConfig = baseConfig) => {
+  jest.spyOn(LLMConfigManager.prototype, 'loadConfig').mockResolvedValue(config);
+  jest
+    .spyOn(LLMConfigManager.prototype, 'getModelConfig')
+    .mockImplementation(async (provider: LLMProvider, model?: string) => {
+      const providerConfig = config.providers[provider];
+      const selectedModel = (model ?? providerConfig.defaultModel) as keyof typeof providerConfig.models;
+      const models = providerConfig.models as Record<string, { maxTokens: number; available: boolean }>;
+      const entry = models[selectedModel as string];
+      if (!entry) {
+        throw new Error(`Model '${String(model)}' not available for provider '${provider}'`);
+      }
+      return { model: selectedModel, maxTokens: entry.maxTokens };
+    });
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('LLMManager', () => {
   const createManager = () => {
-    const secretManager = {
-      getSecret: jest.fn(async () => 'key')
-    } as any;
-    const manager = new LLMManager(secretManager as SecretManager);
-    const configManager = {
-      loadConfig: jest.fn(async () => baseConfig),
-      getModelConfig: jest.fn(async (provider: string, model?: string) => {
-        if (provider === 'openai') {
-          return { model: model ?? 'gpt-4', maxTokens: 4096 };
-        }
-        return { model: model ?? 'claude-3-haiku-20240307', maxTokens: 4096 };
-      })
-    } as any;
-    (manager as any).configManager = configManager;
-    return { manager, configManager } as const;
+    setupConfigSpies();
+    return new LLMManager(createSecretManager());
   };
 
   it('initializes clients based on config and caches completions', async () => {
-    const { manager } = createManager();
+    const manager = createManager();
 
     const openaiCreate = jest.fn(async () => ({
       choices: [{ message: { content: 'response' } }],
       usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 }
     }));
 
-    (manager as any).clients = new Map([
-      ['openai', {
+    (manager as unknown as { clients: Record<string, unknown> }).clients = {
+      openai: {
         chat: {
           completions: { create: openaiCreate }
         }
-      }]
-    ]);
+      }
+    };
 
     const request = { message: 'Hi', provider: 'openai' as const };
 
@@ -88,39 +108,148 @@ describe('LLMManager', () => {
     expect(openaiCreate).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to claude when requested provider fails', async () => {
-    const { manager, configManager } = createManager();
+  it('falls back to Claude when requested provider fails', async () => {
+    const manager = createManager();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
 
     const anthropicResponse = {
       content: [{ type: 'text', text: 'fallback' }],
-      usage: { input_tokens: 5, output_tokens: 10, total_tokens: 15 }
+      usage: {
+        input_tokens: 5,
+        output_tokens: 10,
+        cache_creation: null,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        server_tool_use: null,
+        service_tier: null
+      }
     };
 
-    const openaiCreate = jest.fn(async () => { throw new Error('openai failure'); });
+    const openaiCreate = jest.fn(async () => {
+      throw new Error('openai failure');
+    });
     const anthropicCreate = jest.fn(async () => anthropicResponse);
 
-    (manager as any).clients = new Map([
-      ['openai', {
+    (manager as unknown as { clients: Record<string, unknown> }).clients = {
+      openai: {
         chat: {
           completions: { create: openaiCreate }
         }
-      }],
-      ['claude', {
+      },
+      claude: {
         messages: { create: anthropicCreate }
-      }]
-    ]);
-
-    (configManager as any).getModelConfig = jest.fn(async (provider: string) => {
-      if (provider === 'openai') {
-        return { model: 'gpt-4', maxTokens: 4096 };
       }
-      return { model: 'claude-3-haiku-20240307', maxTokens: 4096 };
-    });
+    };
 
     const response = await manager.complete({ message: 'Fallback', provider: 'openai' });
 
     expect(response.provider).toBe('claude');
     expect(openaiCreate).toHaveBeenCalled();
     expect(anthropicCreate).toHaveBeenCalled();
+  });
+});
+
+describe('LLMManager error handling', () => {
+  const mockConfig: LLMConfig = baseConfig;
+
+  beforeEach(() => {
+    setupConfigSpies(mockConfig);
+  });
+
+  it('falls back to Claude when the requested provider fails', async () => {
+    const manager = new LLMManager(createSecretManager());
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const openAiError = new Error('OpenAI down');
+    const openAiClient = {
+      chat: {
+        completions: {
+          create: jest.fn(async () => {
+            throw openAiError;
+          })
+        }
+      }
+    };
+
+    const claudeResponse = {
+      content: [{ type: 'text', text: 'Fallback response' }],
+      usage: {
+        input_tokens: 12,
+        output_tokens: 6,
+        cache_creation: null,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        server_tool_use: null,
+        service_tier: null
+      }
+    };
+    const claudeClient = {
+      messages: {
+        create: jest.fn(async () => claudeResponse)
+      }
+    };
+
+    (manager as unknown as { clients: Record<string, unknown> }).clients = {
+      openai: openAiClient,
+      claude: claudeClient
+    };
+
+    const result = await manager.complete({ provider: 'openai', message: 'hello' });
+
+    expect(openAiClient.chat.completions.create).toHaveBeenCalledTimes(1);
+    expect(claudeClient.messages.create).toHaveBeenCalledTimes(1);
+    expect(result.provider).toBe('claude');
+    expect(result.content).toBe('Fallback response');
+    expect(result.usage).toEqual({ promptTokens: 12, completionTokens: 6, totalTokens: 18 });
+  });
+
+  it('throws a descriptive error when fallback provider is unavailable', async () => {
+    const manager = new LLMManager(createSecretManager());
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const openAiClient = {
+      chat: {
+        completions: {
+          create: jest.fn(async () => {
+            throw new Error('OpenAI down');
+          })
+        }
+      }
+    };
+
+    (manager as unknown as { clients: Record<string, unknown> }).clients = {
+      openai: openAiClient
+    };
+
+    await expect(
+      manager.complete({ provider: 'openai', message: 'hello' })
+    ).rejects.toThrow("LLM request failed: LLM provider 'claude' not available");
+  });
+
+  it('surfaces errors from Claude when no fallback is available', async () => {
+    const manager = new LLMManager(createSecretManager());
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const claudeClient = {
+      messages: {
+        create: jest.fn(async () => {
+          throw new Error('Claude offline');
+        })
+      }
+    };
+
+    (manager as unknown as { clients: Record<string, unknown> }).clients = {
+      claude: claudeClient
+    };
+
+    await expect(
+      manager.complete({ provider: 'claude', message: 'hello' })
+    ).rejects.toThrow('LLM request failed: Claude offline');
+
+    expect(claudeClient.messages.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/secrets/managers/environment.test.ts
+++ b/test/unit/secrets/managers/environment.test.ts
@@ -1,0 +1,33 @@
+import { EnvironmentSecretManager } from '../../../../src/secrets/managers/environment.js';
+
+describe('EnvironmentSecretManager', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns existing environment variables', async () => {
+    process.env.TEST_SECRET = 'super-secret';
+    const manager = new EnvironmentSecretManager();
+
+    await expect(manager.getSecret('TEST_SECRET')).resolves.toBe('super-secret');
+  });
+
+  it('throws when environment variable is missing', async () => {
+    const manager = new EnvironmentSecretManager();
+
+    await expect(manager.getSecret('MISSING_SECRET')).rejects.toThrow('Environment variable MISSING_SECRET not found');
+  });
+
+  it('reports availability and name', async () => {
+    const manager = new EnvironmentSecretManager();
+
+    await expect(manager.isAvailable()).resolves.toBe(true);
+    expect(manager.getName()).toBe('Environment');
+  });
+});

--- a/test/unit/secrets/managers/file.test.ts
+++ b/test/unit/secrets/managers/file.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { FileSecretManager } from '../../../../src/secrets/managers/file.js';
+
+describe('FileSecretManager', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'file-secret-manager-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  const createEnvFile = (fileName: string, contents: string) => {
+    const filePath = join(tempDir, fileName);
+    writeFileSync(filePath, contents);
+    return filePath;
+  };
+
+  it('loads secrets from an env file and trims quotes', async () => {
+    const envPath = createEnvFile('.env.local', `# comment\nAPI_KEY=abc123\nQUOTED="quoted value"\nMULTI=value=with=equals\n`);
+    const manager = new FileSecretManager(envPath);
+
+    await expect(manager.getSecret('API_KEY')).resolves.toBe('abc123');
+    await expect(manager.getSecret('QUOTED')).resolves.toBe('quoted value');
+    await expect(manager.getSecret('MULTI')).resolves.toBe('value=with=equals');
+  });
+
+  it('throws when secret is missing', async () => {
+    const envPath = createEnvFile('.env', 'API_KEY=abc123');
+    const manager = new FileSecretManager(envPath);
+
+    await expect(manager.getSecret('MISSING')).rejects.toThrow(`Secret MISSING not found in ${envPath}`);
+  });
+
+  it('caches parsed secrets after first load', async () => {
+    const envPath = createEnvFile('.env.caching', 'TOKEN=test-token');
+    const manager = new FileSecretManager(envPath);
+
+    await expect(manager.getSecret('TOKEN')).resolves.toBe('test-token');
+    writeFileSync(envPath, 'TOKEN=changed');
+    await expect(manager.getSecret('TOKEN')).resolves.toBe('test-token');
+    expect(manager['loaded']).toBe(true);
+  });
+
+  it('exposes availability based on file existence', async () => {
+    const existingEnv = createEnvFile('.env.available', 'VALUE=1');
+    const existingManager = new FileSecretManager(existingEnv);
+    const missingManager = new FileSecretManager(join(tempDir, 'missing.env'));
+
+    await expect(existingManager.isAvailable()).resolves.toBe(true);
+    await expect(missingManager.isAvailable()).resolves.toBe(false);
+  });
+
+  it('wraps file load errors with descriptive message', async () => {
+    const missingPath = join(tempDir, 'missing.env');
+    const manager = new FileSecretManager(missingPath);
+
+    await expect(manager.getSecret('ANY')).rejects.toThrow(`Failed to load ${missingPath}`);
+  });
+});

--- a/test/unit/server/http-server.test.ts
+++ b/test/unit/server/http-server.test.ts
@@ -1,0 +1,72 @@
+import { MCPHttpServer } from '../../../src/server/http-server.js';
+import { EnvironmentConfig } from '../../../src/config/environment.js';
+import { OAuthProviderFactory } from '../../../src/auth/factory.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+
+describe('MCPHttpServer', () => {
+  const originalSecurityConfig = EnvironmentConfig.getSecurityConfig;
+  const originalIsDevelopment = EnvironmentConfig.isDevelopment;
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    (EnvironmentConfig as any).getSecurityConfig = jest.fn().mockReturnValue({ requireHttps: false });
+    (EnvironmentConfig as any).isDevelopment = jest.fn().mockReturnValue(true);
+    Object.assign(OAuthProviderFactory, {
+      createFromEnvironment: jest.fn().mockReturnValue({
+        getEndpoints: () => ({
+          authEndpoint: '/auth',
+          callbackEndpoint: '/callback',
+          refreshEndpoint: '/refresh',
+          logoutEndpoint: '/logout'
+        }),
+        handleAuthorizationRequest: jest.fn(),
+        handleAuthorizationCallback: jest.fn(),
+        handleTokenRefresh: jest.fn(),
+        handleLogout: jest.fn()
+      })
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    EnvironmentConfig.getSecurityConfig = originalSecurityConfig;
+    EnvironmentConfig.isDevelopment = originalIsDevelopment;
+  });
+
+  const makeServer = (options?: Partial<ConstructorParameters<typeof MCPHttpServer>[0]>) =>
+    new MCPHttpServer({
+      port: 8080,
+      host: '127.0.0.1',
+      endpoint: '/sse',
+      requireAuth: false,
+      sessionSecret: 'secret',
+      ...options
+    });
+
+  it('stops server when close is available', async () => {
+    const server = makeServer();
+    const close = jest.fn((cb) => { cb?.(); return undefined; });
+    (server as any).server = {
+      close,
+      on: jest.fn()
+    };
+
+    await expect(server.stop()).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('registers SSE connection handler', async () => {
+    const server = makeServer();
+    const handler = jest.fn().mockResolvedValue(undefined);
+    server.onSSEConnection(handler);
+
+    const transport = {} as unknown as SSEServerTransport;
+    await (server as any).sseConnectionHandler(transport);
+    expect(handler).toHaveBeenCalledWith(transport);
+  });
+
+  it('invokes OAuth provider factory when auth required', () => {
+    makeServer({ requireAuth: true });
+    expect(OAuthProviderFactory.createFromEnvironment).toHaveBeenCalled();
+  });
+});

--- a/test/unit/server/mcp-setup.test.ts
+++ b/test/unit/server/mcp-setup.test.ts
@@ -2,21 +2,37 @@ import { jest } from '@jest/globals';
 import { setupMCPServer } from '../../../src/server/mcp-setup.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
-jest.mock('../../../src/tools/llm/chat.js', () => ({
-  handleChatTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'chat' }] }))
-}));
+jest.mock('../../../src/tools/llm/chat.js', () => {
+  const parseChatToolInput = jest.fn(() => ({ message: 'hello' }));
+  return {
+    handleChatTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'chat' }] })),
+    parseChatToolInput
+  };
+});
 
-jest.mock('../../../src/tools/llm/analyze.js', () => ({
-  handleAnalyzeTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'analyze' }] }))
-}));
+jest.mock('../../../src/tools/llm/analyze.js', () => {
+  const parseAnalyzeToolInput = jest.fn(() => ({ text: 'analyze this' }));
+  return {
+    handleAnalyzeTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'analyze' }] })),
+    parseAnalyzeToolInput
+  };
+});
 
-jest.mock('../../../src/tools/llm/summarize.js', () => ({
-  handleSummarizeTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'summarize' }] }))
-}));
+jest.mock('../../../src/tools/llm/summarize.js', () => {
+  const parseSummarizeToolInput = jest.fn(() => ({ text: 'summarize this' }));
+  return {
+    handleSummarizeTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'summarize' }] })),
+    parseSummarizeToolInput
+  };
+});
 
-jest.mock('../../../src/tools/llm/explain.js', () => ({
-  handleExplainTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'explain' }] }))
-}));
+jest.mock('../../../src/tools/llm/explain.js', () => {
+  const parseExplainToolInput = jest.fn(() => ({ topic: 'explain this' }));
+  return {
+    handleExplainTool: jest.fn(async () => ({ content: [{ type: 'text', text: 'explain' }] })),
+    parseExplainToolInput
+  };
+});
 
 describe('setupMCPServer', () => {
   const createServer = () => {
@@ -73,7 +89,8 @@ describe('setupMCPServer', () => {
 
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const response = await callHandler!({ params: { name: 'chat', arguments: { message: 'hello' } } });
-    const { handleChatTool } = await import('../../../src/tools/llm/chat.js');
+    const { handleChatTool, parseChatToolInput } = await import('../../../src/tools/llm/chat.js');
+    expect(parseChatToolInput).toHaveBeenCalledWith({ message: 'hello' });
     expect(handleChatTool).toHaveBeenCalledWith({ message: 'hello' }, llmManager);
     expect(response.content[0].text).toBe('chat');
 

--- a/test/unit/server/streamable-http-server.test.ts
+++ b/test/unit/server/streamable-http-server.test.ts
@@ -1,0 +1,77 @@
+import { MCPStreamableHttpServer } from '../../../src/server/streamable-http-server.js';
+import { EnvironmentConfig } from '../../../src/config/environment.js';
+import { OAuthProviderFactory } from '../../../src/auth/factory.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+describe('MCPStreamableHttpServer', () => {
+  const originalSecurityConfig = EnvironmentConfig.getSecurityConfig;
+  const originalIsDevelopment = EnvironmentConfig.isDevelopment;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    (EnvironmentConfig as any).getSecurityConfig = jest.fn().mockReturnValue({ requireHttps: false });
+    (EnvironmentConfig as any).isDevelopment = jest.fn().mockReturnValue(true);
+    Object.assign(OAuthProviderFactory, {
+      createFromEnvironment: jest.fn().mockReturnValue({
+        getEndpoints: () => ({
+          authEndpoint: '/auth',
+          callbackEndpoint: '/callback',
+          refreshEndpoint: '/refresh',
+          logoutEndpoint: '/logout'
+        }),
+        handleAuthorizationRequest: jest.fn(),
+        handleAuthorizationCallback: jest.fn(),
+        handleTokenRefresh: jest.fn(),
+        handleLogout: jest.fn()
+      })
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    EnvironmentConfig.getSecurityConfig = originalSecurityConfig;
+    EnvironmentConfig.isDevelopment = originalIsDevelopment;
+  });
+
+  const makeServer = (options?: Partial<ConstructorParameters<typeof MCPStreamableHttpServer>[0]>) =>
+    new MCPStreamableHttpServer({
+      port: 8081,
+      host: '127.0.0.1',
+      endpoint: '/stream',
+      requireAuth: false,
+      sessionSecret: 'secret',
+      enableResumability: false,
+      enableJsonResponse: false,
+      ...options
+    });
+
+  it('stops the streamable server via close callback', async () => {
+    const server = makeServer();
+    const close = jest.fn((cb) => { cb?.(); return undefined; });
+    (server as any).server = {
+      close,
+      on: jest.fn()
+    };
+
+    await expect(server.stop()).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('registers streamable transport handler', async () => {
+    const server = makeServer();
+    const handler = jest.fn().mockResolvedValue(undefined);
+    server.onStreamableHTTPTransport(handler);
+
+    const transport = {} as unknown as StreamableHTTPServerTransport;
+    await (server as any).streamableTransportHandler(transport);
+    expect(handler).toHaveBeenCalledWith(transport);
+  });
+
+  it('provides session manager access', () => {
+    const server = makeServer({ enableResumability: true });
+    const manager = server.getSessionManager();
+    expect(manager).toBeDefined();
+    expect(manager.getStats()).toHaveProperty('activeSessions');
+  });
+});

--- a/test/unit/session/event-store.test.ts
+++ b/test/unit/session/event-store.test.ts
@@ -1,0 +1,124 @@
+import { MemoryEventStore, EventStoreFactory } from '../../../src/session/event-store.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+describe('MemoryEventStore', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const createMessage = (id: string): JSONRPCMessage => ({
+    jsonrpc: '2.0',
+    id,
+    method: 'test',
+    params: { value: id }
+  });
+
+  it('stores events and replays them after a given id', async () => {
+    const store = new MemoryEventStore();
+    const internal = store as unknown as {
+      events: Map<string, unknown>;
+      streamEvents: Map<string, string[]>;
+    };
+
+    const firstId = await store.storeEvent('stream-1', createMessage('1'));
+    const secondId = await store.storeEvent('stream-1', createMessage('2'));
+    const thirdId = await store.storeEvent('stream-1', createMessage('3'));
+
+    expect(internal.events.size).toBe(3);
+    expect(internal.streamEvents.get('stream-1')).toEqual([firstId, secondId, thirdId]);
+
+    const send = jest.fn().mockResolvedValue(undefined);
+    const streamId = await store.replayEventsAfter(firstId, { send });
+
+    expect(streamId).toBe('stream-1');
+    expect(send).toHaveBeenNthCalledWith(1, secondId, expect.objectContaining({ id: '2' }));
+    expect(send).toHaveBeenNthCalledWith(2, thirdId, expect.objectContaining({ id: '3' }));
+
+    store.destroy();
+  });
+
+  it('throws when replaying from unknown event', async () => {
+    const store = new MemoryEventStore();
+    await expect(store.replayEventsAfter('missing', { send: jest.fn() })).rejects.toThrow('Event not found: missing');
+    store.destroy();
+  });
+
+  it('enforces max events per stream', async () => {
+    const store = new MemoryEventStore();
+    const internal = store as unknown as {
+      events: Map<string, unknown>;
+      streamEvents: Map<string, string[]>;
+    };
+
+    const total = 1005;
+    const ids: string[] = [];
+    for (let i = 0; i < total; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      ids.push(await store.storeEvent('stream-x', createMessage(String(i))));
+    }
+
+    expect(internal.streamEvents.get('stream-x')?.length).toBeLessThanOrEqual(1000);
+    expect(internal.events.size).toBe(internal.streamEvents.get('stream-x')?.length);
+
+    store.destroy();
+  });
+
+  it('cleans up expired events', async () => {
+    const store = new MemoryEventStore();
+    const internal = store as unknown as {
+      events: Map<string, { timestamp: number }>;
+      streamEvents: Map<string, string[]>;
+      cleanup(): void;
+    };
+
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    const eventId = await store.storeEvent('stream-1', createMessage('keep'));
+
+    jest.setSystemTime(new Date('2024-01-03T00:00:00Z')); // >24h later
+    internal.cleanup();
+
+    expect(internal.events.has(eventId)).toBe(false);
+    expect(internal.streamEvents.get('stream-1')).toBeUndefined();
+
+    store.destroy();
+  });
+
+  it('reports aggregate statistics', async () => {
+    const store = new MemoryEventStore();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    await store.storeEvent('stream-1', createMessage('1'));
+
+    const stats = store.getStats();
+    expect(stats.totalEvents).toBe(1);
+    expect(stats.totalStreams).toBe(1);
+    expect(stats.oldestEventAge).toBe(0);
+
+    store.destroy();
+  });
+
+  it('destroy clears state and cancels interval', () => {
+    const store = new MemoryEventStore();
+    const internal = store as unknown as { cleanupInterval?: NodeJS.Timeout; events: Map<string, unknown> };
+
+    store.destroy();
+    expect(internal.cleanupInterval).toBeUndefined();
+    expect(internal.events.size).toBe(0);
+  });
+});
+
+describe('EventStoreFactory', () => {
+  it('creates memory store by default', () => {
+    const store = EventStoreFactory.createEventStore();
+    expect(store).toBeInstanceOf(MemoryEventStore);
+    (store as MemoryEventStore).destroy();
+  });
+
+  it('throws for unsupported type', () => {
+    expect(() => EventStoreFactory.createEventStore('unsupported' as never)).toThrow('Unsupported event store type');
+  });
+});

--- a/test/unit/session/session-manager.test.ts
+++ b/test/unit/session/session-manager.test.ts
@@ -1,0 +1,90 @@
+import { SessionManager } from '../../../src/session/session-manager.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+
+const createAuthInfo = (token: string): AuthInfo => ({
+  token,
+  clientId: 'client',
+  scopes: ['scope'],
+  expiresAt: Date.now() / 1000 + 3600
+});
+
+describe('SessionManager', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('creates, retrieves, updates, and closes sessions', () => {
+    const manager = new SessionManager();
+
+    const session = manager.createSession(createAuthInfo('token-1'), { foo: 'bar' });
+    expect(session.sessionId).toBeDefined();
+
+    const fetched = manager.getSession(session.sessionId);
+    expect(fetched?.authInfo?.token).toBe('token-1');
+
+    manager.updateSession(session.sessionId, {
+      authInfo: createAuthInfo('token-2'),
+      metadata: { baz: 'qux' }
+    });
+
+    const updated = manager.getSession(session.sessionId);
+    expect(updated?.authInfo?.token).toBe('token-2');
+    expect(updated?.metadata).toEqual({ foo: 'bar', baz: 'qux' });
+
+    expect(manager.closeSession(session.sessionId)).toBe(true);
+    expect(manager.getSession(session.sessionId)).toBeUndefined();
+    expect(manager.closeSession('missing')).toBe(false);
+
+    manager.destroy();
+  });
+
+  it('validates session expiration', () => {
+    const manager = new SessionManager();
+    const session = manager.createSession();
+
+    expect(manager.isSessionValid(session.sessionId)).toBe(true);
+
+    jest.setSystemTime(new Date('2024-01-02T01:00:00Z')); // > 24h later
+    expect(manager.isSessionValid(session.sessionId)).toBe(false);
+    expect(manager.getSession(session.sessionId)).toBeUndefined();
+
+    manager.destroy();
+  });
+
+  it('reports session statistics and cleanup removes stale sessions', () => {
+    const manager = new SessionManager();
+    const active = manager.createSession();
+    const expired = manager.createSession();
+
+    jest.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+    manager.getSession(active.sessionId);
+
+    jest.setSystemTime(new Date('2024-01-02T12:00:00Z'));
+    const internal = manager as unknown as { cleanup(): void };
+    internal.cleanup();
+
+    const stats = manager.getStats();
+    expect(stats.totalSessions).toBe(1);
+    expect(stats.activeSessions).toBe(1);
+    expect(stats.expiredSessions).toBe(0);
+    expect(manager.getActiveSessions().map(s => s.sessionId)).toEqual([active.sessionId]);
+    expect(manager.getSession(expired.sessionId)).toBeUndefined();
+
+    manager.destroy();
+  });
+
+  it('destroys session manager and clears timers', () => {
+    const manager = new SessionManager();
+    const internal = manager as unknown as { cleanupInterval?: NodeJS.Timeout; sessions: Map<string, unknown> };
+    manager.createSession();
+
+    manager.destroy();
+    expect(internal.cleanupInterval).toBeUndefined();
+    expect(internal.sessions.size).toBe(0);
+  });
+});

--- a/test/unit/tools/llm/tools-error.test.ts
+++ b/test/unit/tools/llm/tools-error.test.ts
@@ -1,0 +1,77 @@
+import { jest } from '@jest/globals';
+import { handleChatTool } from '../../../../src/tools/llm/chat.js';
+import { handleAnalyzeTool } from '../../../../src/tools/llm/analyze.js';
+import { handleSummarizeTool } from '../../../../src/tools/llm/summarize.js';
+import { handleExplainTool } from '../../../../src/tools/llm/explain.js';
+import type { LLMManager } from '../../../../src/llm/manager.js';
+
+type ToolResponse = {
+  content: Array<{ type: string; [key: string]: unknown }>;
+};
+
+type ToolScenario = {
+  tool: string;
+  handler: (input: any, manager: LLMManager) => Promise<ToolResponse>;
+  defaults: { provider: string; model: string };
+  input: Record<string, unknown>;
+};
+
+describe('LLM tool error handling', () => {
+  const createManager = (defaults: { provider: string; model: string }) => {
+    const completeMock = jest.fn();
+
+    const manager = {
+      getProviderForTool: jest.fn().mockReturnValue(defaults),
+      getAvailableProviders: jest.fn().mockReturnValue([defaults.provider]),
+      complete: completeMock,
+      clearCache: jest.fn(),
+      getCacheStats: jest.fn(),
+      initialize: jest.fn(),
+      isProviderAvailable: jest.fn().mockReturnValue(true)
+    } as unknown as LLMManager;
+
+    return { manager, completeMock };
+  };
+
+  const extractJsonError = (result: ToolResponse) =>
+    result.content.find(item => item.type === 'json') as { json: { error: { tool: string; message: string } } } | undefined;
+
+  const scenarios: ToolScenario[] = [
+    {
+      tool: 'chat',
+      handler: handleChatTool as ToolScenario['handler'],
+      defaults: { provider: 'claude', model: 'claude-3-haiku-20240307' },
+      input: { message: 'hello', provider: 'claude', model: 'gpt-4' }
+    },
+    {
+      tool: 'analyze',
+      handler: handleAnalyzeTool as ToolScenario['handler'],
+      defaults: { provider: 'openai', model: 'gpt-4' },
+      input: { text: 'analyze me', provider: 'openai', model: 'claude-3-haiku-20240307' }
+    },
+    {
+      tool: 'summarize',
+      handler: handleSummarizeTool as ToolScenario['handler'],
+      defaults: { provider: 'gemini', model: 'gemini-1.5-flash' },
+      input: { text: 'summarize me', provider: 'gemini', model: 'gpt-4' }
+    },
+    {
+      tool: 'explain',
+      handler: handleExplainTool as ToolScenario['handler'],
+      defaults: { provider: 'claude', model: 'claude-3-haiku-20240307' },
+      input: { topic: 'explain', provider: 'claude', model: 'gpt-4' }
+    }
+  ];
+
+  it.each(scenarios)('returns structured error content for invalid %s requests', async ({ tool, handler, defaults, input }) => {
+    const { manager, completeMock } = createManager(defaults);
+
+    const result = await handler(input, manager);
+
+    const jsonError = extractJsonError(result);
+    expect(jsonError).toBeDefined();
+    expect(jsonError?.json.error.tool).toBe(tool);
+    expect(jsonError?.json.error.message).toContain('not valid');
+    expect(completeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
  - Elevated global Jest coverage gates in jest.config.js, then broadened feature tests so the suite now enforces 30 %+ statements/lines and 20 %+ branches.
  - Hardened the OAuth stack: src/auth/factory.ts now tracks active providers, registers a process- exit hook, and surfaces aggregated disposal errors; supporting tweaks in src/auth/providers/ base-provider.ts, google-provider.ts, and types.ts align type contracts with the richer lifecycle management.
  - Refined the LLM control plane. src/llm/config.ts expands secret loading diagnostics and provider validation, while src/llm/manager.ts reorganizes client registries, typing, and response handling across Anthropic/OpenAI/Gemini to support stricter model checks, caching, and structured tool errors.
  - Updated downstream touchpoints—file secrets (src/secrets/managers/file.ts), tiered secret manager, tool handlers (src/tools/llm/*.ts), MCP server wiring (src/server/mcp-setup.ts), and transport factory—to consume the new validation paths and bubble up rich error details.
  - Added substantial unit coverage: dedicated suites for each OAuth provider (test/unit/auth/ providers/*.test.ts), the OAuth factory, secret managers, event store, session manager, transport factory edge cases, server scaffolding, and LLM/tool error behaviors (test/unit/session/ *.test.ts, test/unit/server/*.test.ts, test/unit/tools/llm/tools-error.test.ts, etc.). These tests run purely in-memory—no real sockets or credentials—and assert both success flows and failure semantics.