### PR TITLE
Fix LLM provider/model mismatch (Issue #44)

### DIFF
--- a/src/tools/llm/analyze.ts
+++ b/src/tools/llm/analyze.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod';
 import { LLMManager } from '../../llm/manager.js';
-import { AnyModel, isValidModelForProvider } from '../../llm/types.js';
+import { AnyModel, isValidModelForProvider, getDefaultModelForProvider } from '../../llm/types.js';
 
 type ToolResponse = {
   content: Array<{ type: 'text'; text: string }>;
@@ -48,7 +48,14 @@ export async function handleAnalyzeTool(
     // Get default provider/model for analyze tool if not specified
     const toolDefaults = llmManager.getProviderForTool('analyze');
     const provider = input.provider || toolDefaults.provider;
-    const model = input.model ?? toolDefaults.model;
+
+    // If user specified provider without model, use that provider's default model
+    let model: string | undefined;
+    if (input.provider && !input.model) {
+      model = getDefaultModelForProvider(input.provider);
+    } else {
+      model = input.model ?? toolDefaults.model;
+    }
 
     if (model && !isValidModelForProvider(provider, model as AnyModel)) {
       throw new Error(`Model '${model}' is not valid for provider '${provider}'`);

--- a/src/tools/llm/chat.ts
+++ b/src/tools/llm/chat.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod';
 import { LLMManager } from '../../llm/manager.js';
-import { AnyModel, isValidModelForProvider } from '../../llm/types.js';
+import { AnyModel, isValidModelForProvider, getDefaultModelForProvider } from '../../llm/types.js';
 
 type ToolResponse = {
   content: Array<{ type: 'text'; text: string }>;
@@ -62,7 +62,14 @@ export async function handleChatTool(
     // Get default provider/model for chat tool if not specified
     const toolDefaults = llmManager.getProviderForTool('chat');
     const provider = input.provider ?? toolDefaults.provider;
-    const model = input.model ?? toolDefaults.model;
+
+    // If user specified provider without model, use that provider's default model
+    let model: string | undefined;
+    if (input.provider && !input.model) {
+      model = getDefaultModelForProvider(input.provider);
+    } else {
+      model = input.model ?? toolDefaults.model;
+    }
 
     if (model && !isValidModelForProvider(provider, model as AnyModel)) {
       throw new Error(`Model '${model}' is not valid for provider '${provider}'`);

--- a/src/tools/llm/explain.ts
+++ b/src/tools/llm/explain.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod';
 import { LLMManager } from '../../llm/manager.js';
-import { AnyModel, isValidModelForProvider } from '../../llm/types.js';
+import { AnyModel, isValidModelForProvider, getDefaultModelForProvider } from '../../llm/types.js';
 
 type ToolResponse = {
   content: Array<{ type: 'text'; text: string }>;
@@ -55,7 +55,14 @@ export async function handleExplainTool(
     // Get default provider/model for explain tool if not specified
     const toolDefaults = llmManager.getProviderForTool('explain');
     const provider = input.provider || toolDefaults.provider;
-    const model = input.model ?? toolDefaults.model;
+
+    // If user specified provider without model, use that provider's default model
+    let model: string | undefined;
+    if (input.provider && !input.model) {
+      model = getDefaultModelForProvider(input.provider);
+    } else {
+      model = input.model ?? toolDefaults.model;
+    }
 
     if (model && !isValidModelForProvider(provider, model as AnyModel)) {
       throw new Error(`Model '${model}' is not valid for provider '${provider}'`);

--- a/src/tools/llm/summarize.ts
+++ b/src/tools/llm/summarize.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod';
 import { LLMManager } from '../../llm/manager.js';
-import { AnyModel, isValidModelForProvider, LLMProvider } from '../../llm/types.js';
+import { AnyModel, isValidModelForProvider, LLMProvider, getDefaultModelForProvider } from '../../llm/types.js';
 
 type ToolResponse = {
   content: Array<{ type: 'text'; text: string }>;
@@ -90,7 +90,14 @@ export async function handleSummarizeTool(
     // Get default provider/model for summarize tool if not specified
     const toolDefaults = llmManager.getProviderForTool('summarize');
     const provider = input.provider || toolDefaults.provider;
-    const model = input.model ?? toolDefaults.model;
+
+    // If user specified provider without model, use that provider's default model
+    let model: string | undefined;
+    if (input.provider && !input.model) {
+      model = getDefaultModelForProvider(input.provider);
+    } else {
+      model = input.model ?? toolDefaults.model;
+    }
 
     if (model && !isValidModelForProvider(provider, model as AnyModel)) {
       throw new Error(`Model '${model}' is not valid for provider '${provider}'`);


### PR DESCRIPTION
## Summary

Fixes #44 - Resolves LLM provider/model mismatch when provider is specified without an explicit model.

### Problem
When users specify a `provider` parameter without a `model` in LLM-powered tools (`summarize`, `analyze`, `chat`, `explain`), the tools use incompatible provider/model combinations, causing validation errors like:
```
Model 'gemini-2.5-flash' is not valid for provider 'openai'
```

### Root Cause
This issue was partially fixed in PR #40 but the fix was incomplete:
- ✅ `src/llm/manager.ts` was updated correctly
- ❌ Tool handlers (`summarize.ts`, `analyze.ts`, `chat.ts`, `explain.ts`) were not updated

### Solution
Update all LLM tool handlers to use `getDefaultModelForProvider()` when a provider is specified without a model:

```typescript
let model: string | undefined;
if (input.provider && !input.model) {
  // User specified provider without model - use that provider's default
  model = getDefaultModelForProvider(input.provider);
} else {
  // Use explicit model or tool default model
  model = input.model ?? toolDefaults.model;
}
```

### Files Changed
- `src/tools/llm/summarize.ts`
- `src/tools/llm/analyze.ts`
- `src/tools/llm/chat.ts`
- `src/tools/llm/explain.ts`

### Testing
Comprehensive tests already exist in `test/unit/tools/llm/summarize.test.ts` that verify:
- `provider="openai"` without model uses `gpt-4o-mini`
- `provider="claude"` without model uses `claude-3-5-haiku-20241022`
- `provider="gemini"` without model uses `gemini-2.5-flash`

These tests now pass after this fix is applied.

## Test plan
- [x] Run existing unit tests: `npm run test:unit` - PASSED
- [x] Run full validation: `npm run validate` - PASSED
- [ ] Verify CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)