### PR TITLE
fix: Simplify Vercel deployment for serverless functions

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -22,34 +22,13 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build project
-        run: npm run build
-        env:
-          # Build-time environment variables (if needed)
-          NODE_ENV: production
-
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Deploy Project Artifacts to Vercel
+      - name: Deploy to Vercel Production
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          url=$(vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} --yes)
           echo "deployment_url=$url" >> $GITHUB_OUTPUT
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Problem

The initial Vercel deployment workflow from PR #75 failed with:
```
Error: No Output Directory named "public" found after the Build completed.
```

**Root cause:** The workflow was using `vercel build --prod` which expects a static site build with an output directory. This project uses Vercel serverless functions (`api/` directory), not static site builds.

## Solution

Simplified the deployment workflow to deploy serverless functions directly:

**Removed unnecessary steps:**
- `npm ci` and `npm run build` - Not needed for serverless deployment
- `vercel pull` - Not needed for direct deployment  
- `vercel build --prod` - This was causing the error
- `vercel deploy --prebuilt` - Wrong deployment method for serverless

**New approach:**
- Deploy directly with `vercel deploy --prod --yes`
- Let Vercel handle the build process for serverless functions
- Much simpler and appropriate for this project's architecture

## Changes

- Simplified `.github/workflows/vercel.yml`
- Removed 5 unnecessary workflow steps
- Kept health check verification
- Kept issue comment notification

## Testing Plan

After merge:
1. Workflow will trigger automatically
2. Vercel will deploy serverless functions from `api/` directory
3. Health check will verify `/health` endpoint
4. Issue #74 will receive deployment comment

## Related

- Fixes deployment failure from PR #75
- Related to Issue #74