### PR TITLE
fix: Configure vercel.json to skip build for serverless functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
+  "buildCommand": "echo 'Serverless functions - no build needed'",
   "rewrites": [
     {
       "source": "/health",


### PR DESCRIPTION
## Problem

Even after simplifying the GitHub Actions workflow (PR #76), Vercel deployments still fail with:
```
Error: No Output Directory named "public" found after the Build completed.
```

**Root cause:** Vercel's platform automatically runs `npm run build` during deployment and expects static site output. This project uses serverless functions (`api/` directory) which don't produce static output.

## Solution

Add `buildCommand` to `vercel.json` to override Vercel's default build behavior:

```json
{
  "buildCommand": "echo 'Serverless functions - no build needed'"
}
```

This tells Vercel to skip the static site build and deploy the serverless functions directly.

## Changes

- Added `buildCommand` field to `vercel.json`
- Uses a no-op command that won't fail
- Lets Vercel handle serverless function deployment without static build

## Testing

After merge, the Vercel deployment workflow will:
1. Deploy `api/` directory functions directly
2. Not attempt to build static output
3. Not look for `public/` directory
4. Complete successfully

## Related

- Fixes deployment failures from PR #75 and PR #76
- Related to Issue #74