### PR TITLE
fix: Set buildCommand and outputDirectory to null for serverless functions

### DIFF
--- a/test/integration/health-routes.test.ts
+++ b/test/integration/health-routes.test.ts
@@ -259,7 +259,7 @@ describe('Health Routes Integration', () => {
       // Full token should not appear anywhere in response
       const responseText = JSON.stringify(response.body);
       expect(responseText).not.toContain(testToken);
-    });
+    }, 20000); // Increase timeout for external API call
   });
 
   describe('Health endpoints CORS', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "buildCommand": "echo 'Serverless functions - no build needed'",
+  "buildCommand": null,
+  "outputDirectory": null,
   "rewrites": [
     {
       "source": "/health",


### PR DESCRIPTION
## Summary
- Set `buildCommand: null` and `outputDirectory: null` in vercel.json for serverless functions deployment
- Fixed flaky test by increasing timeout from 10s to 20s for external GitHub API call

## Problem
Previous attempts to fix Vercel deployment used `buildCommand: "echo 'Serverless functions - no build needed'"`, but Vercel still expected an output directory. For pure serverless function deployments (using `api/` directory), both buildCommand and outputDirectory should be explicitly set to `null`.

## Changes
1. **vercel.json**: Set both `buildCommand` and `outputDirectory` to `null`
2. **test/integration/health-routes.test.ts**: Increased timeout from 10s to 20s for test that makes external GitHub API call

## Test Plan
- ✅ All validation tests pass locally
- ✅ Flaky test now has proper timeout
- 🔄 Will verify Vercel deployment succeeds after merge

## Related
- Fixes deployment error: `No Output Directory named "public" found after Build`
- Addresses issue #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)