### PR TITLE
fix: Remove buildCommand and outputDirectory from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "buildCommand": null,
-  "outputDirectory": null,
   "rewrites": [
     {
       "source": "/health",


### PR DESCRIPTION
## Summary
Remove `buildCommand` and `outputDirectory` fields from vercel.json to fix serverless deployment

## Problem  
Setting `buildCommand: null` and `outputDirectory: null` in PR #78 didn't work - Vercel ignores null values and still tries to build, looking for a "public" output directory.

## Root Cause
Vercel treats `null` values the same as if the fields weren't set with explicit configuration, but when explicitly set to null in JSON, Vercel's parser may trigger default build behavior.

## Solution
Remove these fields entirely from vercel.json. For serverless function deployments (using `api/` directory), Vercel should auto-detect and deploy without requiring build configuration.

## Changes
- Removed `buildCommand: null` from vercel.json  
- Removed `outputDirectory: null` from vercel.json

## Test Plan
- ✅ All validation tests pass locally
- 🔄 Will verify Vercel deployment succeeds after merge

## Related
- Addresses issue #74
- Supersedes PR #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)