### PR TITLE
chore: Update vibe-validate to v0.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6352,15 +6352,15 @@
       }
     },
     "node_modules/@vibe-validate/cli": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@vibe-validate/cli/-/cli-0.10.2.tgz",
-      "integrity": "sha512-R6UIAtE217jtl0G/d4cP0Qckb2jtfLb45hvk6hwQoKn1oRkpe6xt20z5syabaENMCkVryNR3So1SH7sI/MNWkA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@vibe-validate/cli/-/cli-0.10.3.tgz",
+      "integrity": "sha512-NzeXwdVcUo77vUf3SdM5g6rV3qVsRKIiT2f06fzMeFKAbT9DhEysnCnU4TDhMzY64dyxj4A5MxuubvKjnMDpGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vibe-validate/config": "0.10.2",
-        "@vibe-validate/core": "0.10.2",
-        "@vibe-validate/git": "0.10.2",
+        "@vibe-validate/config": "0.10.3",
+        "@vibe-validate/core": "0.10.3",
+        "@vibe-validate/git": "0.10.3",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "js-yaml": "^4.1.0",
@@ -6385,9 +6385,9 @@
       }
     },
     "node_modules/@vibe-validate/config": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@vibe-validate/config/-/config-0.10.2.tgz",
-      "integrity": "sha512-Xs7VHiILrIRN+G019ggQshm3G/eaOcEx5BZjJYF3miTmP/khxnI+8vvqw1aX5AZuzaYsw3oGY/sxdXw9pyD0Uw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@vibe-validate/config/-/config-0.10.3.tgz",
+      "integrity": "sha512-9B3HANgHoZ8GDWEkgBSEPGXzEKCpPWzySYh1X9N8CNhP20OaiVtIYEuIKkUGWTsjl9J9B0NKdKhQe5puUrulvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6401,13 +6401,13 @@
       }
     },
     "node_modules/@vibe-validate/core": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@vibe-validate/core/-/core-0.10.2.tgz",
-      "integrity": "sha512-XKANnoxNASv0ULnxyrOf63IEI8dGZi6h3F6gXPCY9jmBv6Cl//89ulziFuGtt5UvPdIjzZHiLpTvDMArL/uIOQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@vibe-validate/core/-/core-0.10.3.tgz",
+      "integrity": "sha512-3Fd/RRu7sWFbpmgGo1cjNFpjhBRkvk+LvuFgmbcHi3Nex6pB5QqGL5E+/3OL9l41KAafhSV+QZLdV8M/MN/FXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vibe-validate/git": "0.10.2",
+        "@vibe-validate/git": "0.10.3",
         "js-yaml": "^4.1.0",
         "yaml": "^2.6.1"
       },
@@ -6416,9 +6416,9 @@
       }
     },
     "node_modules/@vibe-validate/formatters": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@vibe-validate/formatters/-/formatters-0.10.2.tgz",
-      "integrity": "sha512-kZGvu6U3t4hlk26ZtU0gOKcLV4Q7bg7pSQ468vj2MSoY/y+sRSIJ9x5T2FCFbu8wkCfiCu1HlpO1tAJ0U0GUBA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@vibe-validate/formatters/-/formatters-0.10.3.tgz",
+      "integrity": "sha512-iJEW1GySoZ63sp9yK8Qs1a96cSEqsp3RhgTmIrq6svge9GcXdYHHmeOz02V9brbK+fkLyGrmvA7UoUAEpUygFw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6426,9 +6426,9 @@
       }
     },
     "node_modules/@vibe-validate/git": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@vibe-validate/git/-/git-0.10.2.tgz",
-      "integrity": "sha512-ac2CH5c+ZiuXNWDxaIOoMwFypCiB+58JleTl8c4R5zOYqIChaVT/kgj3by2fmqzDSNONJ4TFlFtmnf+tQhE0lw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@vibe-validate/git/-/git-0.10.3.tgz",
+      "integrity": "sha512-V7fUZIlJCPt1sslwk4ITRw7jvAEgh278ybn6UQ34Au7FDcdKSDK/E7ZzqPZTeVTkTN5HaY4k/zUDv2WERZc7tw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
Updates all vibe-validate packages from v0.10.0 to v0.10.3.

## Changes
- Updated @vibe-validate/cli to v0.10.3
- Updated @vibe-validate/config to v0.10.3
- Updated @vibe-validate/core to v0.10.3
- Updated @vibe-validate/formatters to v0.10.3
- Updated @vibe-validate/git to v0.10.3

## Validation
✅ All validation checks passed (both phases)
✅ `vibe-validate doctor` reports all 15 checks passing with no recommendations
✅ Version confirmed up to date (v0.10.3)

## Test Plan
- [x] Full validation passed (Phase 1 + Phase 2)
- [x] Doctor diagnostics confirm healthy setup (15/15 checks)
- [x] Version verification confirms v0.10.3
- [x] Pre-commit hook validation passed

🤖 Generated with [Claude Code](https://claude.ai/code)