### PR TITLE
chore: Release v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-typescript-simple",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "A framework for building TypeScript MCP servers",
   "main": "packages/example-mcp/dist/index.js",
   "type": "module",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/adapter-vercel",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Vercel serverless adapter for MCP TypeScript Simple server",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/auth",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "OAuth 2.0/2.1 + Dynamic Client Registration (DCR) implementation for MCP servers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/config",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Extensible configuration management for MCP servers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-mcp-typescript-simple/package.json
+++ b/packages/create-mcp-typescript-simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mcp-typescript-simple",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Scaffolding tool for creating production-ready MCP TypeScript Simple servers",
   "type": "module",
   "bin": {

--- a/packages/example-mcp/package.json
+++ b/packages/example-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/example-mcp",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Example MCP server demonstrating framework usage",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/example-tools-basic/package.json
+++ b/packages/example-tools-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/example-tools-basic",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Example: Basic MCP tools for demonstration and testing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/example-tools-llm/package.json
+++ b/packages/example-tools-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/example-tools-llm",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Example: LLM-powered MCP tools for demonstration and testing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/http-server",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "HTTP server infrastructure for MCP with session management, middleware, and transport layers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/observability",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Production-ready OpenTelemetry observability for MCP servers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/persistence",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Pluggable persistence layer for MCP servers with memory, file, and Redis support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/server",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "High-level MCP server creation and management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/testing",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Reusable MCP testing framework with port management, process utilities, and Playwright helpers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tools-llm/package.json
+++ b/packages/tools-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/tools-llm",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "LLM infrastructure for building LLM-powered MCP tools",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/tools",
-  "version": "0.9.0-rc.13",
+  "version": "0.9.0",
   "description": "Core tool system for building MCP tools in TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v0.9.0

This PR bumps all workspace packages to version 0.9.0 for the stable release.

### Changes
- Updated all 15 package.json files from 0.9.0-rc.13 to 0.9.0
- Ready for npm publication

### Checklist
- [x] Version consistency across all packages
- [x] CHANGELOG.md updated for v0.9.0
- [x] Build succeeds
- [x] All tests pass

### Post-Merge Steps
1. Merge this PR
2. Tag will already exist: `v0.9.0`
3. Publish to npm: `npm run publish:all`

🤖 Generated with [Claude Code](https://claude.ai/code)