### PR TITLE
feat: Add .gitattributes to scaffold template for cross-platform support

### DIFF
--- a/packages/create-mcp-typescript-simple/src/generator.ts
+++ b/packages/create-mcp-typescript-simple/src/generator.ts
@@ -17,6 +17,7 @@ function getTemplateFiles(_config: ProjectConfig): TemplateFile[] {
     { source: 'package.json.hbs', destination: 'package.json', isTemplate: true },
     { source: 'tsconfig.json', destination: 'tsconfig.json', isTemplate: false },
     { source: 'gitignore', destination: '.gitignore', isTemplate: false },
+    { source: '.gitattributes', destination: '.gitattributes', isTemplate: false },
     { source: 'eslint.config.js', destination: 'eslint.config.js', isTemplate: false },
     { source: 'README.md.hbs', destination: 'README.md', isTemplate: true },
     { source: 'CLAUDE.md.hbs', destination: 'CLAUDE.md', isTemplate: true },

--- a/packages/create-mcp-typescript-simple/templates/.gitattributes
+++ b/packages/create-mcp-typescript-simple/templates/.gitattributes
@@ -1,0 +1,65 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
+# Explicitly declare text files
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+*.txt text eol=lf
+*.xml text eol=lf
+*.svg text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.lock text eol=lf
+Dockerfile* text eol=lf
+*.dockerfile text eol=lf
+
+# Declare files that will always have CRLF line endings on checkout
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Denote binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.woff2 binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary
+*.jar binary
+*.so binary
+*.dylib binary
+*.dll binary
+*.exe binary
+
+# Exclude files from export
+.gitattributes export-ignore
+.gitignore export-ignore
+.editorconfig export-ignore


### PR DESCRIPTION
## Summary

Adds comprehensive `.gitattributes` configuration to the scaffold template so all generated MCP servers have consistent line ending handling across Windows/Mac/Linux.

## Problem

Generated MCP servers lacked `.gitattributes`, causing:
- CRLF/LF line ending issues on Windows
- Broken bash scripts in Docker containers
- CI/CD failures due to line ending mismatches
- Binary file corruption

## Solution

**What Changed:**
- ✅ Added `.gitattributes` file to scaffold template directory
- ✅ Updated `generator.ts` to include `.gitattributes` in template file list

**Result:**
All new MCP servers created with `npm create @mcp-typescript-simple@latest` now include `.gitattributes` with:
- LF line endings for all text files
- CRLF preserved for Windows batch/PowerShell files
- Binary file protection (images, fonts, archives)

## Verification

- ✅ Created test project - `.gitattributes` properly installed (1119 bytes)
- ✅ Full validation passed (all 12 steps)
- ✅ Content verified - all line ending rules correct

## Testing

Generated a test project and confirmed:
```bash
$ ls -la test-project/.gitattributes
-rw-------  1 user  group  1119 Nov 21 00:08 .gitattributes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)