### PR TITLE
chore: Release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.2] - 2025-12-11
+
+### Fixed
+
+- **Fixed Direct OAuth Flow failing with 'invalid_grant' error** (Issue #107)
+  - **Problem**: OAuth clients providing their own PKCE parameters (e.g., Claude Code, MCP Inspector) failed during token exchange because the server wasn't storing authorization code mappings
+  - **Root Cause**: In Direct OAuth Flow, the server wasn't storing the authorization code in the PKCE store, causing provider identification to fail in multi-provider deployments
+  - **Solution**: Always store authorization code mappings using empty string `''` as sentinel value for Direct OAuth Flow, allowing provider identification while maintaining security
+  - **Impact**: Claude Code and MCP Inspector OAuth integrations now work correctly; multi-provider routing works as expected
+
+### Added
+
+- **Comprehensive getting-started documentation**
+  - `docs/getting-started/01-overview.md` - Framework overview and architecture
+  - `docs/getting-started/02-http-session-management.md` - HTTP session management patterns
+  - `docs/getting-started/03-tool-registry-http-mode.md` - Tool registry for HTTP mode
+
+### Improved
+
+- **Test coverage for Direct OAuth Flow** - Added 11 comprehensive test cases validating authorization, token exchange, and provider identification
+- **Reduced code duplication** - Refactored test helpers to eliminate 42 lines of duplicated code (14.3% reduction)
+- **PKCE validation** - Implemented proper SHA256 code_challenge verification in tests
+
+---
+
 ## [0.9.1-rc.2] - 2025-11-28
 
 ### Added

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/adapter-vercel",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Vercel serverless adapter for MCP TypeScript Simple server",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/auth",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "OAuth 2.0/2.1 + Dynamic Client Registration (DCR) implementation for MCP servers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/config",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Extensible configuration management for MCP servers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-mcp-typescript-simple/package.json
+++ b/packages/create-mcp-typescript-simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mcp-typescript-simple",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Scaffolding tool for creating production-ready MCP TypeScript Simple servers",
   "type": "module",
   "bin": {

--- a/packages/example-mcp/package.json
+++ b/packages/example-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/example-mcp",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Example MCP server demonstrating framework usage",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/example-tools-basic/package.json
+++ b/packages/example-tools-basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/example-tools-basic",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Example: Basic MCP tools for demonstration and testing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/example-tools-llm/package.json
+++ b/packages/example-tools-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/example-tools-llm",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Example: LLM-powered MCP tools for demonstration and testing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/http-server",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "HTTP server infrastructure for MCP with session management, middleware, and transport layers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/observability",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Production-ready OpenTelemetry observability for MCP servers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/persistence",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Pluggable persistence layer for MCP servers with memory, file, and Redis support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/server",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "High-level MCP server creation and management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/testing",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Reusable MCP testing framework with port management, process utilities, and Playwright helpers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tools-llm/package.json
+++ b/packages/tools-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/tools-llm",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "LLM infrastructure for building LLM-powered MCP tools",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-typescript-simple/tools",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.2",
   "description": "Core tool system for building MCP tools in TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release commit for v0.9.2

- Version bump to 0.9.2
- CHANGELOG updated with bug fixes and improvements

Tag v0.9.2 already pushed to GitHub.